### PR TITLE
Fix countdown minute display bug

### DIFF
--- a/src/countdown.rs
+++ b/src/countdown.rs
@@ -31,16 +31,19 @@ impl CD {
             let m = ((secs % 3600) / 60) as usize;
             let s = (secs % 60) as usize;
             let mut digits = Vec::new();
+
             if h > 0 {
                 digits.push(h / 10);
                 digits.push(h % 10);
                 digits.push(COLON);
             }
-            if m > 0 {
+
+            if h > 0 || m > 0 {
                 digits.push(m / 10);
                 digits.push(m % 10);
                 digits.push(COLON);
             }
+
             digits.push(s / 10);
             digits.push(s % 10);
             digits


### PR DESCRIPTION
## Summary
- always render minutes in countdown when hours are present

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_687c3f2a7f4483209b640d8c0557b9b1